### PR TITLE
ci: move Linux CI to self-hosted ARC (sized -4/-8)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - ever-k8s-linux-x64-4
+    - ever-k8s-linux-x64-8

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -4,7 +4,7 @@ on: pull_request
 jobs:
   codespell:
     name: Codespell
-    runs-on: ubuntu-latest
+    runs-on: ever-k8s-linux-x64-4
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -4,7 +4,7 @@ on: pull_request
 jobs:
   codespell:
     name: Codespell
-    runs-on: ever-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ever-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ever-k8s-linux-x64-4
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Move Linux CI to sized self-hosted ARC runners

Migrates cloud-hosted Linux CI jobs to sized self-hosted ARC labels (`ever-k8s-linux-x64-4` / `ever-k8s-linux-x64-8`) running on the `ever-k8s` cluster.

### Runner mapping applied
- `ubuntu-latest` → `ever-k8s-linux-x64-4`
- (2-core/4-core → `-4`; 8-core → `-8`, per standard sizing)

### Jobs migrated
- **→ ever-k8s-linux-x64-4:** 2 jobs
  - `codespell.yaml` → `codespell`
  - `publish.yaml` → `publish`
- **→ ever-k8s-linux-x64-8:** 0 jobs

### actionlint
- Added `.github/actionlint.yaml` declaring both self-hosted labels (`ever-k8s-linux-x64-4`, `ever-k8s-linux-x64-8`) under `self-hosted-runner.labels` so actionlint accepts the new runners.

### Left hosted (intentionally unchanged)
- **CodeQL** (`github/codeql-action`) — stays on GitHub-hosted.
- **macOS / Windows** runners — unchanged.
- **ARM** (`*-arm`, `ubicloud-standard-8-arm`) — unchanged.
- **16-core** (`ubuntu-latest-16-cores`) — unchanged.
- Fork-PR CI remains disabled (self-hosted runners are not exposed to fork PRs).

_Note: this repo currently has no ARM / 16-core / CodeQL / macOS / Windows jobs; those exclusions are stated for completeness and future-proofing._

Reviewable PR only — not for auto-merge.